### PR TITLE
Compile `user_dir` for all Unix & Redox targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,22 +88,18 @@ pub fn home_dir() -> Option<PathBuf> {
 
 }}
 
-#[cfg(any(target_os = "linux", target_os = "redox"))]
+cfg_if! { if #[cfg(any(target_family = "unix", target_os = "redox"))] {
+
 mod xdg_user_dirs;
 
-#[cfg(any(target_os = "linux", target_os = "redox"))]
 use std::path::Path;
-
-#[cfg(any(target_os = "linux", target_os = "redox"))]
 use std::collections::HashMap;
 
-#[cfg(any(target_os = "linux", target_os = "redox"))]
 fn user_dir_file(home_dir: &Path) -> PathBuf {
     env::var_os("XDG_CONFIG_HOME").and_then(is_absolute_path).unwrap_or_else(|| home_dir.join(".config")).join("user-dirs.dirs")
 }
 
 // this could be optimized further to not create a map and instead retrieve the requested path only
-#[cfg(any(target_os = "linux", target_os = "redox"))]
 pub fn user_dir(user_dir_name: &str) -> Option<PathBuf> {
     if let Some(home_dir) = home_dir() {
         xdg_user_dirs::single(&home_dir, &user_dir_file(&home_dir), user_dir_name).remove(user_dir_name)
@@ -112,11 +108,11 @@ pub fn user_dir(user_dir_name: &str) -> Option<PathBuf> {
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "redox"))]
 pub fn user_dirs(home_dir_path: &Path) -> HashMap<String, PathBuf> {
     xdg_user_dirs::all(home_dir_path, &user_dir_file(home_dir_path))
 }
 
+}}
 
 cfg_if! { if #[cfg(target_os = "windows")] {
 


### PR DESCRIPTION
This change broadens the list of targets which will conditionally
compile the `user_dir` and `user_dirs` functions. Prior to this change,
only the Linux and Redox OS targets will compile an implementation
meaning that other Unix derivatives such as Android, FreeBSD, NetBSD,
Darwin, etc. would not have a compiled implementation of these
functions. Once paired and consumed by the upstream `dirs` crate this
would lead to a compilation failure on these "extra" targets. This
change allows all Unix family targets in addition to the Redox OS target
to compile the same implementation.

Closes #1

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>