### PR TITLE
Update `target_os = "unix"` to `target_family = "unix"`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ pub fn home_dir() -> Option<PathBuf> {
 }}
 
 cfg_if! { if #[cfg(all(
-    any(target_os = "unix", target_os = "redox"),
+    any(target_family = "unix", target_os = "redox"),
     not(any(target_os = "macos", target_os = "ios"))))] {
 
 mod xdg_user_dirs;


### PR DESCRIPTION
This is a fix for 51b0e46b89a76abf9ba9b2551f369a009927f11b where the target family of unix should be selected, rather than target os of unix which doesn't match anything. The unfortunate outcome of current master now is that Linux fails to compile as it doesn't get a conditional compilation block that matches. This fix should clean that up.

@soc Sorry this crept through--I visually reviewed your update to #2 and didn't catch that one `target_os` vs. `target_family`. I did run this patch on a FreeBSD and Linux system to confirm, as well as on macOS to confirm that the functions are *not* compiled as expected.