### PR TITLE
Remove cfg-if dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,6 @@ license     = "MIT OR Apache-2.0"
 repository  = "https://github.com/soc/dirs-sys-rs"
 maintenance = { status = "as-is" }
 
-[dependencies]
-cfg-if = "0.1"
-
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Functions may change or disappear without warning or any kind of deprecation per
 This library is written in Rust, and supports Linux, Redox, macOS and Windows.
 Other platforms are also supported; they use the Linux conventions.
 
-The minimal required version of Rust is 1.13.
+The minimal required version of Rust is 1.13 except for Redox, where the minimum Rust version
+depends on the [`redox_users`](https://crates.io/crates/redox_users) crate.
 
 ## Build
 


### PR DESCRIPTION
This is to allow the crate to compile with rustc 1.13.

The documentation is updated to indicate that a higher version of the compiler may be needed for Redox, since `redox_users` does not document a minimum rustc version.

This is a first step towards fixing https://github.com/soc/dirs-rs/issues/25.